### PR TITLE
Added working version of lnx_if for OSX

### DIFF
--- a/agents/check_mk_agent.macosx
+++ b/agents/check_mk_agent.macosx
@@ -25,6 +25,7 @@
 # Boston, MA 02110-1301 USA.
 
 # NOTE: This agent has beed adapted from the Check_MK linux agent.
+# NOTE2: lnx_if requires iproute2mac to be installed (i.e. `brew install iproute2mac`)
 
 # Remove locale settings to eliminate localized outputs where possible
 # Author: Christian Zigotzky <info@xenosoft.de>
@@ -165,7 +166,7 @@ echo Version: 1.5.0p20
 echo AgentOS: macosx $osver
 
 echo '<<<df>>>'
-df -kPT hfs,apfs | egrep -v "Time Machine|com.apple.TimeMachine.localsnapshots|/Volumes/Recovery|/private/var/vm" | sed 1d | \
+df -kPT hfs,apfs | egrep -v "Time Machine|com.apple.TimeMachine.localsnapshots|/Volumes/|/private/var/vm" | sed 1d | \
 while read DEV REST; do
     TYPE=$(diskutil info "$DEV" | grep '^\s*Type' | cut -d: -f2 | tr -d '[:space:]')
     echo "$DEV $TYPE $REST"
@@ -192,11 +193,42 @@ tr -d ' '` | bc
 # checks plugins with subchecks for parsing that output. Maybe reduce
 # the output size by grepping away totally useless parts
 
-echo '<<<netctr>>>';
-date +'%s'; netstat -inb | egrep -v '(^Name|lo|plip)' | grep Link | awk '{
-print $1,$7,$5,$6,"0","0","0","0","0",$10,$8,$9,"0","0",$11,"0","0"; }'
-# FIXME: send netstat -inb plain, write proper check plugins for
-# clean parsing of the output
+# Mac version of lnx_if. Needs `iproute2mac` to have been installed.
+if hash ip 2>/dev/null; then
+    echo '<<<lnx_if>>>'
+
+    interfaces=$(ip a | grep '^\S' | grep -E -v '^(awdl0|utun)' | awk -F ':' '{ print $1 }')
+    counter=0
+    echo "[start_iplink]"
+    while read -r eth; do
+        counter=$((counter+1))
+        echo -n "${counter}: "
+        ip a show "$eth"
+    done <<< "$interfaces"
+    echo "[end_iplink]"
+
+    echo '<<<lnx_if:sep(58)>>>'
+    netstat=$(netstat -inbd | grep -E "$interfaces" | grep Link)
+    # Format: Name, IBytes, IPckts, IErr, Drop, 0 (fifo), 0 (frame), 0 (compressed), 0 (multicast), Coll, Obyts, OPckts, OErrs, 0 (drop), 0 (fifo), 0 (coll), 0 (drop)
+    #      (Collisions & drops are not broken out into in/out, so I'm assuming receive for now)
+    echo "$netstat" | awk '{print "\t"$1":\t"$7"\t"$5"\t"$6"\t"$12"\t0\t0\t0\t0\t"$11"\t"$10"\t"$8"\t"$9"\t0\t0\t0\t0"}'
+    # Convert osx ifconfig to lnx_if format:
+    #   Note: Wifi interfaces may have variable speeds each call
+    for eth in $interfaces; do
+        cur_ifconfig=$(ifconfig -v "$eth")
+        speed=$(echo "$cur_ifconfig" | grep -E "^\s*(down)?link rate:\s*" | cut -d " " -f3,4 | sed -E 's, (.)bps$,\1b/s,')
+        addr=$(echo "$cur_ifconfig" | grep -E '^\s*ether' | cut -d " " -f2)
+        link_detected=no
+        if echo "$cur_ifconfig" | grep -E 'status:\s*active' > /dev/null || [ "$eth" = "lo0" ]; then
+          link_detected=yes
+        fi
+
+        echo "[$eth]"
+        echo -e "\tSpeed: ${speed:-Unknown}"
+        echo -e "\tLink detected: $link_detected"
+        echo -e "\tAddress: ${addr:-00:00:00:00:00:00}"
+    done
+fi
 
 echo '<<<ps>>>'
 ps ax -o user,vsz,rss,pcpu,command | sed -e 1d -e 's/ *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) */(\1,\2,\3,\4) /'
@@ -233,13 +265,6 @@ if [ -r "$MK_CONFDIR/fileinfo.cfg" ] ; then
     done < "$MK_CONFDIR/fileinfo.cfg"
     IFS=$OLD_IFS
 fi
-
-# Doesn't work since 10.14
-# if type tmutil >/dev/null
-# then
-#     echo '<<<timemachine>>>'
-#     tmutil latestbackup 2>&1
-# fi
 
 # temperatures and sensors, requires HardwareMonitor.app or osx-cpu-temp
 if [ -x /Applications/HardwareMonitor.app/Contents/MacOS/hwmonitor ]; then
@@ -484,7 +509,7 @@ fi
 # Agent output snippets created by cronjobs, etc.
 if [ -d "${SPOOLDIR}" ]
 then
-    pushd "${SPOOLDIR}" > /dev/null
+    pushd "${SPOOLDIR}" || exit > /dev/null
     now=$(date +%s)
 
     for file in *
@@ -515,5 +540,5 @@ then
         # Output the file
         cat "$file"
     done
-    popd > /dev/null
+    popd || exit > /dev/null
 fi

--- a/agents/check_mk_agent.macosx
+++ b/agents/check_mk_agent.macosx
@@ -306,7 +306,7 @@ then
             DNAME="$(smartctl -d nvme -i -f brief $REPLY | grep -v 'Family' | grep -E 'Model|^Serial Number' | sed 's/^.*\(  .*\).*$/\1/' | tr '\n' '_' | sed -e 's/  //g' -e 's/ /_/g' -e 's/_$//' -e 's/^APPLE_//')"
             if [ -n "${DNAME}" ]; then
                 # NVME
-                echo "$DNAME NVME $(sed 's/\_[^.]\{0,15\}$//g' <<<${DNAME})"
+                echo "$REPLY NVME $(sed 's/\_[^.]\{0,15\}$//g' <<<${DNAME})"
                 smartctl -d nvme -A $REPLY | sed -e '1,5d; /^$/d'
             fi
         fi


### PR DESCRIPTION
Added working version of lnx_if for OSX (depends on minor modification in CMK codebase).

For this to work, users must install `iproute2mac` via brew.

