### PR TITLE
Re-enable tmutil timemachine check

### DIFF
--- a/agents/check_mk_agent.macosx
+++ b/agents/check_mk_agent.macosx
@@ -400,16 +400,13 @@ if [ -r "$MK_CONFDIR/fileinfo.cfg" ] ; then
 	IFS=$OLD_IFS
 fi
 
-# Doesn't work since 10.14 due to missing permissions for tmutil
-case $osver in
-	10.?.*|10.1[0-3].*)
-		if command -v tmutil >/dev/null 2>&1
-		then
-			echo '<<<timemachine>>>'
-			tmutil latestbackup 2>&1
-		fi
-		;;
-esac
+# Full Disk Access has to be allowed to /bin/sh for this to work on macOS 10.14+
+# Only allow it if you are aware what the security implications of it are!!!
+if command -v tmutil >/dev/null 2>&1
+then
+	echo '<<<timemachine>>>'
+	tmutil latestbackup 2>&1
+fi
 
 # temperatures and sensors, requires HardwareMonitor.app. On newer machines/OSes
 # HardwareMonitor.app has no access to relevant sensors any more and if macOS'

--- a/agents/check_mk_agent.macosx
+++ b/agents/check_mk_agent.macosx
@@ -37,7 +37,7 @@ export LC_ALL=C
 OrigLANG=${LANG}
 unset LANG
 
-CMK_VERSION="2.0.0p19"
+CMK_VERSION="2.3.0p11"
 export MK_LIBDIR='/usr/local/lib/check_mk_agent'
 export MK_CONFDIR='/etc/check_mk'
 export MK_VARDIR='/var/lib/check_mk_agent'


### PR DESCRIPTION
- Re-enable Timemachine Check with a comment that "Full Disk Access" permission is required for 10.14+.
- Update agent version number to a more recent version value